### PR TITLE
enable reordering for todos

### DIFF
--- a/examples/bmi-counter.html
+++ b/examples/bmi-counter.html
@@ -11852,7 +11852,6 @@ function reorderChildren(domNode, bIndex) {
         var move = bIndex[i]
         if (move !== undefined) {
             var node = children[move]
-            domNode.removeChild(node)
             domNode.insertBefore(node, childNodes[i])
         }
     }
@@ -12078,7 +12077,7 @@ function diffChildren(a, b, patch, apply, index) {
     var bLen = bChildren.length
     var len = aLen > bLen ? aLen : bLen
 
-    aChildren = reorder(aChildren, bChildren, len)
+    bChildren = reorder(aChildren, bChildren, len)
 
     for (var i = 0; i < len; i++) {
         var leftNode = aChildren[i]
@@ -12105,9 +12104,9 @@ function diffChildren(a, b, patch, apply, index) {
         }
     }
 
-    if (aChildren.moves) {
+    if (bChildren.moves) {
         // Reorder nodes last
-        apply = appendPatch(apply, new VPatch(VPatch.ORDER, a, aChildren.moves))
+        apply = appendPatch(apply, new VPatch(VPatch.ORDER, a, bChildren.moves))
     }
 
     return apply
@@ -12162,53 +12161,53 @@ function hooks(vNode, patch, index) {
 
 // List diff, naive left to right reordering
 function reorder(aChildren, bChildren, len) {
-    var aKeys = keyIndex(aChildren)
-
-    if (!aKeys) {
-        return aChildren
-    }
-
     var bKeys = keyIndex(bChildren)
 
     if (!bKeys) {
-        return aChildren
+        return bChildren
     }
 
-    var aMatch, bMatch
+    var aKeys = keyIndex(aChildren)
+
+    if (!aKeys) {
+        return bChildren
+    }
+
+    var bMatch = {}, aMatch = {}
+
+    for (var key in bKeys) {
+        bMatch[bKeys[key]] = aKeys[key]
+    }
 
     for (var key in aKeys) {
-        if (key in bKeys) {
-            if (!aMatch) {
-                aMatch = {}
-                bMatch = {}
-            }
-
-            var aIndex = aKeys[key]
-            var bIndex = bKeys[key]
-            aMatch[aIndex] = bIndex
-            bMatch[bIndex] = aIndex
-        }
-    }
-
-    if (!aMatch) {
-        return bChildren
+        aMatch[aKeys[key]] = bKeys[key]
     }
 
     var shuffle = []
     var freeIndex = 0
+    var i = 0
+    var moveIndex = 0
+    var moves = shuffle.moves = {}
 
-    shuffle.moves = bMatch
-
-    for (var i = 0; i < len; i++) {
-        var move = bMatch[i]
+    while (freeIndex < len) {
+        var move = aMatch[i]
         if (move !== undefined) {
-            shuffle[i] = aChildren[move]
+            shuffle[i] = bChildren[move]
+            moves[move] = moveIndex++
+        } else if (i in aMatch) {
+            shuffle[i] = undefined
         } else {
-            while (freeIndex in aMatch) {
+            while (freeIndex in bMatch) {
                 freeIndex++
             }
-            shuffle[i] = aChildren[freeIndex++]
+
+            if (freeIndex < len) {
+                moves[freeIndex] = moveIndex++
+                shuffle[i] = bChildren[freeIndex]
+                freeIndex++
+            }
         }
+        i++
     }
 
     return shuffle

--- a/examples/count.html
+++ b/examples/count.html
@@ -11811,7 +11811,6 @@ function reorderChildren(domNode, bIndex) {
         var move = bIndex[i]
         if (move !== undefined) {
             var node = children[move]
-            domNode.removeChild(node)
             domNode.insertBefore(node, childNodes[i])
         }
     }
@@ -12037,7 +12036,7 @@ function diffChildren(a, b, patch, apply, index) {
     var bLen = bChildren.length
     var len = aLen > bLen ? aLen : bLen
 
-    aChildren = reorder(aChildren, bChildren, len)
+    bChildren = reorder(aChildren, bChildren, len)
 
     for (var i = 0; i < len; i++) {
         var leftNode = aChildren[i]
@@ -12064,9 +12063,9 @@ function diffChildren(a, b, patch, apply, index) {
         }
     }
 
-    if (aChildren.moves) {
+    if (bChildren.moves) {
         // Reorder nodes last
-        apply = appendPatch(apply, new VPatch(VPatch.ORDER, a, aChildren.moves))
+        apply = appendPatch(apply, new VPatch(VPatch.ORDER, a, bChildren.moves))
     }
 
     return apply
@@ -12121,53 +12120,53 @@ function hooks(vNode, patch, index) {
 
 // List diff, naive left to right reordering
 function reorder(aChildren, bChildren, len) {
-    var aKeys = keyIndex(aChildren)
-
-    if (!aKeys) {
-        return aChildren
-    }
-
     var bKeys = keyIndex(bChildren)
 
     if (!bKeys) {
-        return aChildren
+        return bChildren
     }
 
-    var aMatch, bMatch
+    var aKeys = keyIndex(aChildren)
+
+    if (!aKeys) {
+        return bChildren
+    }
+
+    var bMatch = {}, aMatch = {}
+
+    for (var key in bKeys) {
+        bMatch[bKeys[key]] = aKeys[key]
+    }
 
     for (var key in aKeys) {
-        if (key in bKeys) {
-            if (!aMatch) {
-                aMatch = {}
-                bMatch = {}
-            }
-
-            var aIndex = aKeys[key]
-            var bIndex = bKeys[key]
-            aMatch[aIndex] = bIndex
-            bMatch[bIndex] = aIndex
-        }
-    }
-
-    if (!aMatch) {
-        return bChildren
+        aMatch[aKeys[key]] = bKeys[key]
     }
 
     var shuffle = []
     var freeIndex = 0
+    var i = 0
+    var moveIndex = 0
+    var moves = shuffle.moves = {}
 
-    shuffle.moves = bMatch
-
-    for (var i = 0; i < len; i++) {
-        var move = bMatch[i]
+    while (freeIndex < len) {
+        var move = aMatch[i]
         if (move !== undefined) {
-            shuffle[i] = aChildren[move]
+            shuffle[i] = bChildren[move]
+            moves[move] = moveIndex++
+        } else if (i in aMatch) {
+            shuffle[i] = undefined
         } else {
-            while (freeIndex in aMatch) {
+            while (freeIndex in bMatch) {
                 freeIndex++
             }
-            shuffle[i] = aChildren[freeIndex++]
+
+            if (freeIndex < len) {
+                moves[freeIndex] = moveIndex++
+                shuffle[i] = bChildren[freeIndex]
+                freeIndex++
+            }
         }
+        i++
     }
 
     return shuffle

--- a/examples/field-reset.html
+++ b/examples/field-reset.html
@@ -11832,7 +11832,6 @@ function reorderChildren(domNode, bIndex) {
         var move = bIndex[i]
         if (move !== undefined) {
             var node = children[move]
-            domNode.removeChild(node)
             domNode.insertBefore(node, childNodes[i])
         }
     }
@@ -12058,7 +12057,7 @@ function diffChildren(a, b, patch, apply, index) {
     var bLen = bChildren.length
     var len = aLen > bLen ? aLen : bLen
 
-    aChildren = reorder(aChildren, bChildren, len)
+    bChildren = reorder(aChildren, bChildren, len)
 
     for (var i = 0; i < len; i++) {
         var leftNode = aChildren[i]
@@ -12085,9 +12084,9 @@ function diffChildren(a, b, patch, apply, index) {
         }
     }
 
-    if (aChildren.moves) {
+    if (bChildren.moves) {
         // Reorder nodes last
-        apply = appendPatch(apply, new VPatch(VPatch.ORDER, a, aChildren.moves))
+        apply = appendPatch(apply, new VPatch(VPatch.ORDER, a, bChildren.moves))
     }
 
     return apply
@@ -12142,53 +12141,53 @@ function hooks(vNode, patch, index) {
 
 // List diff, naive left to right reordering
 function reorder(aChildren, bChildren, len) {
-    var aKeys = keyIndex(aChildren)
-
-    if (!aKeys) {
-        return aChildren
-    }
-
     var bKeys = keyIndex(bChildren)
 
     if (!bKeys) {
-        return aChildren
+        return bChildren
     }
 
-    var aMatch, bMatch
+    var aKeys = keyIndex(aChildren)
+
+    if (!aKeys) {
+        return bChildren
+    }
+
+    var bMatch = {}, aMatch = {}
+
+    for (var key in bKeys) {
+        bMatch[bKeys[key]] = aKeys[key]
+    }
 
     for (var key in aKeys) {
-        if (key in bKeys) {
-            if (!aMatch) {
-                aMatch = {}
-                bMatch = {}
-            }
-
-            var aIndex = aKeys[key]
-            var bIndex = bKeys[key]
-            aMatch[aIndex] = bIndex
-            bMatch[bIndex] = aIndex
-        }
-    }
-
-    if (!aMatch) {
-        return bChildren
+        aMatch[aKeys[key]] = bKeys[key]
     }
 
     var shuffle = []
     var freeIndex = 0
+    var i = 0
+    var moveIndex = 0
+    var moves = shuffle.moves = {}
 
-    shuffle.moves = bMatch
-
-    for (var i = 0; i < len; i++) {
-        var move = bMatch[i]
+    while (freeIndex < len) {
+        var move = aMatch[i]
         if (move !== undefined) {
-            shuffle[i] = aChildren[move]
+            shuffle[i] = bChildren[move]
+            moves[move] = moveIndex++
+        } else if (i in aMatch) {
+            shuffle[i] = undefined
         } else {
-            while (freeIndex in aMatch) {
+            while (freeIndex in bMatch) {
                 freeIndex++
             }
-            shuffle[i] = aChildren[freeIndex++]
+
+            if (freeIndex < len) {
+                moves[freeIndex] = moveIndex++
+                shuffle[i] = bChildren[freeIndex]
+                freeIndex++
+            }
         }
+        i++
     }
 
     return shuffle

--- a/examples/geometry/index.html
+++ b/examples/geometry/index.html
@@ -1676,7 +1676,6 @@ function reorderChildren(domNode, bIndex) {
         var move = bIndex[i]
         if (move !== undefined) {
             var node = children[move]
-            domNode.removeChild(node)
             domNode.insertBefore(node, childNodes[i])
         }
     }
@@ -1902,7 +1901,7 @@ function diffChildren(a, b, patch, apply, index) {
     var bLen = bChildren.length
     var len = aLen > bLen ? aLen : bLen
 
-    aChildren = reorder(aChildren, bChildren, len)
+    bChildren = reorder(aChildren, bChildren, len)
 
     for (var i = 0; i < len; i++) {
         var leftNode = aChildren[i]
@@ -1929,9 +1928,9 @@ function diffChildren(a, b, patch, apply, index) {
         }
     }
 
-    if (aChildren.moves) {
+    if (bChildren.moves) {
         // Reorder nodes last
-        apply = appendPatch(apply, new VPatch(VPatch.ORDER, a, aChildren.moves))
+        apply = appendPatch(apply, new VPatch(VPatch.ORDER, a, bChildren.moves))
     }
 
     return apply
@@ -1986,53 +1985,53 @@ function hooks(vNode, patch, index) {
 
 // List diff, naive left to right reordering
 function reorder(aChildren, bChildren, len) {
-    var aKeys = keyIndex(aChildren)
-
-    if (!aKeys) {
-        return aChildren
-    }
-
     var bKeys = keyIndex(bChildren)
 
     if (!bKeys) {
-        return aChildren
+        return bChildren
     }
 
-    var aMatch, bMatch
+    var aKeys = keyIndex(aChildren)
+
+    if (!aKeys) {
+        return bChildren
+    }
+
+    var bMatch = {}, aMatch = {}
+
+    for (var key in bKeys) {
+        bMatch[bKeys[key]] = aKeys[key]
+    }
 
     for (var key in aKeys) {
-        if (key in bKeys) {
-            if (!aMatch) {
-                aMatch = {}
-                bMatch = {}
-            }
-
-            var aIndex = aKeys[key]
-            var bIndex = bKeys[key]
-            aMatch[aIndex] = bIndex
-            bMatch[bIndex] = aIndex
-        }
-    }
-
-    if (!aMatch) {
-        return bChildren
+        aMatch[aKeys[key]] = bKeys[key]
     }
 
     var shuffle = []
     var freeIndex = 0
+    var i = 0
+    var moveIndex = 0
+    var moves = shuffle.moves = {}
 
-    shuffle.moves = bMatch
-
-    for (var i = 0; i < len; i++) {
-        var move = bMatch[i]
+    while (freeIndex < len) {
+        var move = aMatch[i]
         if (move !== undefined) {
-            shuffle[i] = aChildren[move]
+            shuffle[i] = bChildren[move]
+            moves[move] = moveIndex++
+        } else if (i in aMatch) {
+            shuffle[i] = undefined
         } else {
-            while (freeIndex in aMatch) {
+            while (freeIndex in bMatch) {
                 freeIndex++
             }
-            shuffle[i] = aChildren[freeIndex++]
+
+            if (freeIndex < len) {
+                moves[freeIndex] = moveIndex++
+                shuffle[i] = bChildren[freeIndex]
+                freeIndex++
+            }
         }
+        i++
     }
 
     return shuffle

--- a/examples/shared-state.html
+++ b/examples/shared-state.html
@@ -11816,7 +11816,6 @@ function reorderChildren(domNode, bIndex) {
         var move = bIndex[i]
         if (move !== undefined) {
             var node = children[move]
-            domNode.removeChild(node)
             domNode.insertBefore(node, childNodes[i])
         }
     }
@@ -12042,7 +12041,7 @@ function diffChildren(a, b, patch, apply, index) {
     var bLen = bChildren.length
     var len = aLen > bLen ? aLen : bLen
 
-    aChildren = reorder(aChildren, bChildren, len)
+    bChildren = reorder(aChildren, bChildren, len)
 
     for (var i = 0; i < len; i++) {
         var leftNode = aChildren[i]
@@ -12069,9 +12068,9 @@ function diffChildren(a, b, patch, apply, index) {
         }
     }
 
-    if (aChildren.moves) {
+    if (bChildren.moves) {
         // Reorder nodes last
-        apply = appendPatch(apply, new VPatch(VPatch.ORDER, a, aChildren.moves))
+        apply = appendPatch(apply, new VPatch(VPatch.ORDER, a, bChildren.moves))
     }
 
     return apply
@@ -12126,53 +12125,53 @@ function hooks(vNode, patch, index) {
 
 // List diff, naive left to right reordering
 function reorder(aChildren, bChildren, len) {
-    var aKeys = keyIndex(aChildren)
-
-    if (!aKeys) {
-        return aChildren
-    }
-
     var bKeys = keyIndex(bChildren)
 
     if (!bKeys) {
-        return aChildren
+        return bChildren
     }
 
-    var aMatch, bMatch
+    var aKeys = keyIndex(aChildren)
+
+    if (!aKeys) {
+        return bChildren
+    }
+
+    var bMatch = {}, aMatch = {}
+
+    for (var key in bKeys) {
+        bMatch[bKeys[key]] = aKeys[key]
+    }
 
     for (var key in aKeys) {
-        if (key in bKeys) {
-            if (!aMatch) {
-                aMatch = {}
-                bMatch = {}
-            }
-
-            var aIndex = aKeys[key]
-            var bIndex = bKeys[key]
-            aMatch[aIndex] = bIndex
-            bMatch[bIndex] = aIndex
-        }
-    }
-
-    if (!aMatch) {
-        return bChildren
+        aMatch[aKeys[key]] = bKeys[key]
     }
 
     var shuffle = []
     var freeIndex = 0
+    var i = 0
+    var moveIndex = 0
+    var moves = shuffle.moves = {}
 
-    shuffle.moves = bMatch
-
-    for (var i = 0; i < len; i++) {
-        var move = bMatch[i]
+    while (freeIndex < len) {
+        var move = aMatch[i]
         if (move !== undefined) {
-            shuffle[i] = aChildren[move]
+            shuffle[i] = bChildren[move]
+            moves[move] = moveIndex++
+        } else if (i in aMatch) {
+            shuffle[i] = undefined
         } else {
-            while (freeIndex in aMatch) {
+            while (freeIndex in bMatch) {
                 freeIndex++
             }
-            shuffle[i] = aChildren[freeIndex++]
+
+            if (freeIndex < len) {
+                moves[freeIndex] = moveIndex++
+                shuffle[i] = bChildren[freeIndex]
+                freeIndex++
+            }
         }
+        i++
     }
 
     return shuffle

--- a/examples/todomvc/index.html
+++ b/examples/todomvc/index.html
@@ -161,7 +161,7 @@ function mainSection(todos, route, events) {
         }),
         h("label", { htmlFor: "toggle-all" }, "Mark all as complete"),
         h("ul#todo-list.todolist", visibleTodos.map(function (todo) {
-            return mercury.partial(todoItem, todo, events)
+            return todoItem(todo, events)
         }))
     ])
 }
@@ -3843,7 +3843,6 @@ function reorderChildren(domNode, bIndex) {
         var move = bIndex[i]
         if (move !== undefined) {
             var node = children[move]
-            domNode.removeChild(node)
             domNode.insertBefore(node, childNodes[i])
         }
     }
@@ -4069,7 +4068,7 @@ function diffChildren(a, b, patch, apply, index) {
     var bLen = bChildren.length
     var len = aLen > bLen ? aLen : bLen
 
-    aChildren = reorder(aChildren, bChildren, len)
+    bChildren = reorder(aChildren, bChildren, len)
 
     for (var i = 0; i < len; i++) {
         var leftNode = aChildren[i]
@@ -4096,9 +4095,9 @@ function diffChildren(a, b, patch, apply, index) {
         }
     }
 
-    if (aChildren.moves) {
+    if (bChildren.moves) {
         // Reorder nodes last
-        apply = appendPatch(apply, new VPatch(VPatch.ORDER, a, aChildren.moves))
+        apply = appendPatch(apply, new VPatch(VPatch.ORDER, a, bChildren.moves))
     }
 
     return apply
@@ -4153,53 +4152,53 @@ function hooks(vNode, patch, index) {
 
 // List diff, naive left to right reordering
 function reorder(aChildren, bChildren, len) {
-    var aKeys = keyIndex(aChildren)
-
-    if (!aKeys) {
-        return aChildren
-    }
-
     var bKeys = keyIndex(bChildren)
 
     if (!bKeys) {
-        return aChildren
+        return bChildren
     }
 
-    var aMatch, bMatch
+    var aKeys = keyIndex(aChildren)
+
+    if (!aKeys) {
+        return bChildren
+    }
+
+    var bMatch = {}, aMatch = {}
+
+    for (var key in bKeys) {
+        bMatch[bKeys[key]] = aKeys[key]
+    }
 
     for (var key in aKeys) {
-        if (key in bKeys) {
-            if (!aMatch) {
-                aMatch = {}
-                bMatch = {}
-            }
-
-            var aIndex = aKeys[key]
-            var bIndex = bKeys[key]
-            aMatch[aIndex] = bIndex
-            bMatch[bIndex] = aIndex
-        }
-    }
-
-    if (!aMatch) {
-        return bChildren
+        aMatch[aKeys[key]] = bKeys[key]
     }
 
     var shuffle = []
     var freeIndex = 0
+    var i = 0
+    var moveIndex = 0
+    var moves = shuffle.moves = {}
 
-    shuffle.moves = bMatch
-
-    for (var i = 0; i < len; i++) {
-        var move = bMatch[i]
+    while (freeIndex < len) {
+        var move = aMatch[i]
         if (move !== undefined) {
-            shuffle[i] = aChildren[move]
+            shuffle[i] = bChildren[move]
+            moves[move] = moveIndex++
+        } else if (i in aMatch) {
+            shuffle[i] = undefined
         } else {
-            while (freeIndex in aMatch) {
+            while (freeIndex in bMatch) {
                 freeIndex++
             }
-            shuffle[i] = aChildren[freeIndex++]
+
+            if (freeIndex < len) {
+                moves[freeIndex] = moveIndex++
+                shuffle[i] = bChildren[freeIndex]
+                freeIndex++
+            }
         }
+        i++
     }
 
     return shuffle

--- a/examples/todomvc/render.js
+++ b/examples/todomvc/render.js
@@ -59,7 +59,7 @@ function mainSection(todos, route, events) {
         }),
         h("label", { htmlFor: "toggle-all" }, "Mark all as complete"),
         h("ul#todo-list.todolist", visibleTodos.map(function (todo) {
-            return mercury.partial(todoItem, todo, events)
+            return todoItem(todo, events)
         }))
     ])
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "observ-hash": "^2.0.0",
     "value-event": "^1.3.0",
     "vdom-thunk": "^1.4.0",
-    "virtual-dom": "0.0.6",
+    "virtual-dom": "0.0.7",
     "virtual-hyperscript": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Updated virtual-dom to v0.0.7
- Took the todos out of a thunk as this was masking the key. Easier than adding key to thunk for now.
- Rebuilt the examples
