### PR TITLE
update observ-varhash

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "observ": "^0.2.0",
     "observ-array": "^1.0.3",
     "observ-struct": "^3.1.0",
-    "observ-varhash": "0.0.2",
+    "observ-varhash": "^0.1.1",
     "value-event": "^1.3.4",
     "vdom-thunk": "^2.0.0",
     "virtual-dom": "0.0.8",


### PR DESCRIPTION
A bit urgent because there's a bug in `0.0.2` where it doesn't propagate changes to the parent `observ`.
