### PR TITLE
improve geometry example

### DIFF
--- a/examples/geometry/drag-handler.js
+++ b/examples/geometry/drag-handler.js
@@ -18,19 +18,26 @@ DragEventHandler.prototype.handleEvent = function (ev) {
     var value = this.value
     var delegator = this.delegator
 
-    var currentX = ev.offsetX || ev.layerX
-    var currentY = ev.offsetY || ev.layerY
+    var current = {
+        x: ev.offsetX || ev.layerX,
+        y: ev.offsetY || ev.layerY
+    }
 
     function onmove(ev) {
+
+        var previous = current
+
+        current = {
+            x: ev.offsetX || ev.layerX,
+            y: ev.offsetY || ev.layerY
+        }
+
         var delta = {
-            x: ev.clientX - currentX,
-            y: ev.clientY - currentY
+            x: current.x - previous.x,
+            y: current.y - previous.y
         }
 
         fn(extend(value, delta))
-
-        currentX = ev.clientX
-        currentY = ev.clientY
     }
 
     function onup(ev) {


### PR DESCRIPTION
- use [`dom-delegator`](https://github.com/Raynos/dom-delegator) to listen to `mousemove` / `mouseup` events instead of `window.addEventListener`
- use `ev.offsetX || ev.layerX` consistently in event handlers instead of using `ev.clientX` to calculate delta on mousemove
- use `{ x, y }` object consistently in drag event handlers

cheers!
