### PR TITLE
Mutable focus hook link fix.

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -132,7 +132,7 @@ h('div', {
 ```
 
 For another example of a hook see
-  [TodoMVC focus hook](https://github.com/Raynos/mercury/blob/master/examples/todomvc/lib/do-mutable-focus.js)
+  [TodoMVC focus hook](https://github.com/Raynos/mercury/blob/master/examples/lib/focus-hook.js)
 
 ## How do I get life cycle hooks for VNodes
 


### PR DESCRIPTION
Updated for deprecated TodoMVC to current example.
