### PR TITLE
Library deprecated: virtual-dom-stringify; replaced with vdom-to-html.

### DIFF
--- a/examples/server-rendering/server.js
+++ b/examples/server-rendering/server.js
@@ -3,7 +3,7 @@
 var http = require('http');
 var browserify = require('browserify');
 var path = require('path');
-var stringify = require('virtual-dom-stringify');
+var toHTML = require('vdom-to-html');
 var JSONGlobals = require('json-globals');
 var h = require('../../index.js').h;
 var logger = require('console');
@@ -30,7 +30,7 @@ var server = http.createServer(function onReq(req, res) {
     var vtree = layout(content, state);
 
     res.setHeader('Content-Type', 'text/html');
-    res.end('<!DOCTYPE html>' + stringify(vtree));
+    res.end('<!DOCTYPE html>' + toHTML(vtree));
 });
 
 server.listen(8000);

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "tape": "^2.13.2",
     "valid-email": "0.0.1",
     "vdom-virtualize": "0.0.5",
-    "virtual-dom-stringify": "^0.2.0",
+    "vdom-to-html": "^1.3.0",
     "vtree-select": "^1.0.1",
     "weakmap-shim": "^1.1.0",
     "zuul": "^1.9.0",


### PR DESCRIPTION
It was preventing 'npm install' form working. Used only in the server-rendering example.
