### PR TITLE
fix invalid sendKey call

### DIFF
--- a/examples/todomvc/todo-item.js
+++ b/examples/todomvc/todo-item.js
@@ -98,7 +98,7 @@ TodoItem.render = function render(todo, parentHandles) {
             // invoked at patch time
             'ev-focus': todo.editing ? FocusHook() : null,
             'ev-keydown': hg.sendKey(
-                todo.channels.cancelEdit, ESCAPE),
+                todo.channels.cancelEdit, null, {key: ESCAPE}),
             'ev-event': hg.sendSubmit(todo.channels.finishEdit),
             'ev-blur': hg.sendValue(todo.channels.finishEdit)
         })


### PR DESCRIPTION
I think something was wrong in the todomvc example : the ESCAPE key had no effect on the input.edit because of an invalid call to hg.sendKey