### PR TITLE
Fixed version of vdom-to-html lib used.

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "tape": "^2.13.2",
     "valid-email": "0.0.1",
     "vdom-virtualize": "0.0.5",
-    "vdom-to-html": "^1.3.0",
+    "vdom-to-html": "~1.2.5",
     "vtree-select": "^1.0.1",
     "weakmap-shim": "^1.1.0",
     "zuul": "^1.9.0",


### PR DESCRIPTION
`vdom-to-html` 1.2.5 is the last version of the lib that supports `virtual-dom` 1.x. Once `mercury` is updated to use `virtual-dom` 2.x this version limitation should be lifted.

This patch fixes the server-rendering example in `examples/server-rendering/server.js`, and also it's the only place where `vdom-to-html` lib is used.

Related: #155 