### PR TITLE
Add example of hot reloading with webpack

### DIFF
--- a/examples/hot-reload-webpack/README.md
+++ b/examples/hot-reload-webpack/README.md
@@ -1,0 +1,32 @@
+# Hot module replacement with webpack
+
+Using hot reloading while developing can improve your workflow.
+No more clicking through your application to a particular state each time you change the rendering code!
+
+## Running the example
+
+This example must be run standalone, instead of through the usual `npm run examples` in this repository's root.
+To install and run it:
+
+    npm install
+    npm run dev
+
+Edit [package.json][] if you want to run on a different port.
+If you're running inside a container or VM, add `--host 0.0.0.0` so you can access the dev server from your host machine.
+
+Try clicking to increment the counter, then edit [render.js][]!
+Your changes should instantly appear on the page without refreshing or upsetting the counter's value.
+Note that if you edit [browser.js][], your page will refresh and your state will be reset.
+
+[package.json]: ./package.json
+[render.js]: ./render.js
+[browser.js]: ./browser.js
+
+## How it works
+
+Running `webpack-dev-server` with the `--hot` argument enables [hot module replacement][], but to make use of it you need to add a little bit of code to your application.
+When webpack detects a file has changed, `module.hot.accept` gets a chance to 'claim' the reload and prevent the page from refreshing as it usually would.
+We use that opportunity to replace the function the app uses to render.
+We have to be careful to not reseat any references - so we pass a function that doesn't change to `hg.app` (i.e. `App.render`), but inside that function, we call a function which may change at runtime.
+
+[hot module replacement]: https://github.com/webpack/docs/wiki/hot-module-replacement-with-webpack

--- a/examples/hot-reload-webpack/browser.js
+++ b/examples/hot-reload-webpack/browser.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var hg = require('../../index.js');
+var document = require('global/document');
+
+// Copied from examples/count.js
+function App() {
+    return hg.state({
+        count: hg.value(0),
+        _hotVersion: hg.value(0), // This is new - see below
+        channels: {
+            clicks: incrementCount,
+        },
+    });
+}
+
+function incrementCount(state) {
+    state.count.set(state.count() + 1);
+}
+
+// This render function may be replaced!
+var render = require('./render.js');
+App.render = function(state) {
+    return render(state);
+};
+
+// Need a reference to this below.
+var appState = App();
+hg.app(document.body, appState, App.render);
+
+// Special sauce: detect changes to the rendering code and swap the rendering
+// function out without reloading the page.
+if (module.hot) {
+    module.hot.accept('./render.js', function() {
+        render = require('./render.js');
+        // Force a re-render by changing the application state.
+        appState._hotVersion.set(appState._hotVersion() + 1);
+        return true;
+    });
+}

--- a/examples/hot-reload-webpack/index.html
+++ b/examples/hot-reload-webpack/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Hot reload example</title>
+    </head>
+    <body>
+        <script src="bundle.js"></script>
+    </body>
+</html>

--- a/examples/hot-reload-webpack/package.json
+++ b/examples/hot-reload-webpack/package.json
@@ -1,0 +1,8 @@
+{
+  "scripts": {
+    "dev": "webpack-dev-server --port 8080 --hot --progress --colors --inline ./browser.js"
+  },
+  "devDependencies": {
+    "webpack-dev-server": "^1.10.1"
+  }
+}

--- a/examples/hot-reload-webpack/render.js
+++ b/examples/hot-reload-webpack/render.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var hg = require('../../index.js');
+var h = hg.h;
+
+module.exports = function(state) {
+    return h('div.counter', [
+        'The state ', h('code', 'count'),
+        ' has value: ' + state.count + '.', h('input.button', {
+            type: 'button',
+            value: 'Click me!',
+            'ev-click': hg.send(state.channels.clicks),
+        })
+    ]);
+};


### PR DESCRIPTION
This is a strawman PR to see if anyone wants this as an example in the main repo. @geelen did the hard work of figuring this out; I've just boiled it down to a minimal example. [Here's](https://github.com/eightyeight/mercury/tree/hot-reload-example/examples/hot-reload-webpack#hot-module-replacement-with-webpack) the readme, rendered. Maybe someone should also come up with a Browserify equivalent? I'm told it's possible, just more work.