### PR TITLE
Allow `true` to be passed into hg.app

### DIFF
--- a/examples/server-rendering/browser.js
+++ b/examples/server-rendering/browser.js
@@ -27,7 +27,7 @@ var app = App(JSONGlobals('state'));
 var targetElem = document.body.firstChild;
 var prevTree = virtualize(targetElem);
 
-hg.app(null, app, App.render, {
+hg.app(true, app, App.render, {
     initialTree: prevTree,
     target: targetElem
 });

--- a/index.js
+++ b/index.js
@@ -120,7 +120,11 @@ function app(elem, observ, render, opts) {
         patch: mercury.patch
     }, opts));
 
-    elem.appendChild(loop.target);
+    // This allows `true` to be passed meaning that the app was
+    // prerendered
+    if (elem !== true) {
+        elem.appendChild(loop.target);
+    }
 
     return observ(loop.update);
 }

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "tap-spec": "^0.2.0",
     "tape": "^2.13.2",
     "valid-email": "0.0.1",
-    "vdom-to-html": "~1.2.5",
+    "vdom-to-html": "~2.2.0",
     "vdom-virtualize": "0.0.5",
     "vtree-select": "^1.0.1",
     "weakmap-shim": "^1.1.0",

--- a/test/index.js
+++ b/test/index.js
@@ -33,3 +33,4 @@ require('./count.js');
 require('./shared-state.js');
 require('./bmi-counter.js');
 require('./time-travel.js');
+require('./ssr.js');

--- a/test/ssr.js
+++ b/test/ssr.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var mercury = require('../index.js');
+var h = mercury.h;
+var document = require('global/document');
+var test = require('tape');
+var virtualize = require('vdom-virtualize');
+var raf = require('raf');
+
+test('Can reattach in the client', function t(assert) {
+    var div = document.createElement('div');
+    div.appendChild(document.createTextNode('Hello world'));
+    document.body.appendChild(div);
+
+    function render(name) {
+        return h('div', 'Hello ' + name);
+    }
+
+    var state = mercury.value('venus');
+
+    mercury.app(true, state, render, {
+        target: div,
+        initialTree: virtualize(div)
+    });
+    state.set(state());
+
+    raf(function afterRender() {
+        var tn = document.body.childNodes[0].childNodes[0];
+
+        assert.equal(tn.data, 'Hello venus', 'Element was updated');
+
+        document.body.removeChild(document.body.childNodes[0]);
+        assert.end();
+    });
+
+});


### PR DESCRIPTION
Client-side reattachment was broken for server-rendered apps because of
8c26d68c65045521bff76dc091c4c23f8a9f65ca.

Another fix was submitted in https://github.com/Raynos/mercury/pull/207
but I think we should preserve the simplicity by using `hg.app` still.
This makes it so that you can pass `true` as the value for the element
which means "this was prerendered".

Test included. Closes #79
